### PR TITLE
✨ Feat(feedback) : columnDefinition 추가

### DIFF
--- a/src/main/java/triplestar/mixchat/domain/learningNote/learningNote/entity/Feedback.java
+++ b/src/main/java/triplestar/mixchat/domain/learningNote/learningNote/entity/Feedback.java
@@ -38,7 +38,7 @@ public class Feedback extends BaseEntity {
     @Column(nullable = false)
     private String extra;
 
-    @Column(name = "is_marked", nullable = false)
+    @Column(name = "is_marked", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private boolean marked = false;
 
     private Feedback(LearningNote learningNote,

--- a/src/main/java/triplestar/mixchat/global/jpa/entity/BaseEntity.java
+++ b/src/main/java/triplestar/mixchat/global/jpa/entity/BaseEntity.java
@@ -22,10 +22,10 @@ public abstract class BaseEntity {
     private Long id;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "modified_at")
+    @Column(name = "modified_at", columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/triplestar/mixchat/global/jpa/entity/BaseEntityNoModified.java
+++ b/src/main/java/triplestar/mixchat/global/jpa/entity/BaseEntityNoModified.java
@@ -1,5 +1,6 @@
 package triplestar.mixchat.global.jpa.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,5 +21,6 @@ public abstract class BaseEntityNoModified {
     private Long id;
 
     @CreatedDate
+    @Column(name = "created_at", columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## 작성 전 체크리스트
- [ ] 빌드 성공 / 테스트 완료
- [ ] 주석 최신화
- [ ] 민감정보 제외
- [ ] 작업파일 코드포맷팅 사용
- [ ] Assignee, Label, Project 설정

## 연관 이슈
- Closes #이슈번호
- Related to #이슈번호

## 작업 내용
- feedback의 is_marked, baseEntity의 createdAt, modifiedAt에 columnDefinition  추가

## 주요 변경 패키지
- domain:
- global:

## 설정 변경사항(.env, yml, gradle)
- 추가: 
- 삭제:
- 없음

## 병합 전 체크리스트
- [ ] 코드리뷰 피드백 반영 완료
- [ ] Notion 문서화 진행중/완료

## 기타사항
추가 전에는 디비버에서 추가시 default가 적용이 안되있는 테이블이라 null값이였음