### PR TITLE
🐛 Fix(rag) : 유사도 튜터의 경우만 rag캐시 저장

### DIFF
--- a/docker/config/flyway/V20__alter__table__feedbacks.sql
+++ b/docker/config/flyway/V20__alter__table__feedbacks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE feedbacks
+    MODIFY COLUMN problem TEXT NOT NULL,
+    MODIFY COLUMN correction TEXT NOT NULL,
+    MODIFY COLUMN extra TEXT NOT NULL;

--- a/src/main/java/triplestar/mixchat/domain/chat/chat/service/AIChatRoomService.java
+++ b/src/main/java/triplestar/mixchat/domain/chat/chat/service/AIChatRoomService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import triplestar.mixchat.domain.ai.userprompt.entity.UserPrompt;
 import triplestar.mixchat.domain.ai.userprompt.repository.UserPromptRepository;
+import triplestar.mixchat.domain.chat.chat.constant.AiChatRoomType;
 import triplestar.mixchat.domain.chat.chat.constant.ChatRoomType;
 import triplestar.mixchat.domain.chat.chat.dto.AIChatRoomResp;
 import triplestar.mixchat.domain.chat.chat.dto.CreateAIChatReq;
@@ -57,7 +58,9 @@ public class AIChatRoomService {
         chatRoomMemberRepository.save(new ChatMember(creator, savedRoom.getId(), ChatRoomType.AI));
         chatRoomMemberRepository.save(new ChatMember(findMemberById(BotConstant.BOT_MEMBER_ID), savedRoom.getId(), ChatRoomType.AI));
 
-        learningNoteSearchService.saveByRecentNotes(savedRoom.getId(), creatorId);
+        if(req.roomType() == AiChatRoomType.TUTOR_SIMILAR) {
+            learningNoteSearchService.saveByRecentNotes(savedRoom.getId(), creatorId);
+        }
         return AIChatRoomResp.from(savedRoom);
     }
 


### PR DESCRIPTION
## 작성 전 체크리스트
- [x] 빌드 성공 / 테스트 완료
- [x] 주석 최신화
- [x] 민감정보 제외
- [x] 작업파일 코드포맷팅 사용
- [x] Assignee, Label, Project 설정

## 연관 이슈
- Closes #이슈번호
- Related to #172 

## 작업 내용
- ai 방 생성시 유사도 튜터 방의 경우만 캐시 저장

## 주요 변경 패키지
- domain: chat
- global:

## 설정 변경사항(.env, yml, gradle)
- 추가: 
- 삭제:
- 없음

## 병합 전 체크리스트
- [ ] 코드리뷰 피드백 반영 완료
- [ ] Notion 문서화 진행중/완료
